### PR TITLE
Ability to specify citation output format

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: recursive
     
-    - name: Checkout submodules
-      uses: textbook/git-checkout-submodule-action@master
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    
+    - name: Checkout submodules
+      uses: textbook/git-checkout-submodule-action@master
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: publish bibserver
+
+on:
+  push:
+    branches:
+    - master    
+
+jobs:
+  publish-bibserver-image:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build the android-sdk-azure-devops-agent Docker image
+      run: |
+        docker build . --tag ghcr.io/jamescoverdale/bibserver:latest        
+        docker push ghcr.io/jamescoverdale/bibserver:latest

--- a/DockerfileSecure
+++ b/DockerfileSecure
@@ -1,0 +1,27 @@
+FROM node:latest
+
+# File Author / Maintainer
+LABEL authors="Vincent Wang"
+
+# Install app dependencies
+COPY package.json /www/package.json
+RUN cd /www; npm install
+
+# Copy app source
+COPY . /www
+
+# Set work directory to /www
+WORKDIR /www
+
+# Fix CSL MLA labelling
+RUN sed -i -e 's/\(<title-short>\).*\(<\/title-short>\)/<title-short>MLA 8<\/title-short>/g' csl/modern-language-association.csl
+RUN sed -i -e 's/\(<title-short>\).*\(<\/title-short>\)/<title-short>MLA 7<\/title-short>/g' csl/modern-language-association-7th-edition.csl
+
+# set your port
+ENV PORT 8080
+
+# expose the port to outside world
+EXPOSE  8080
+
+# start command as per package.json
+CMD ["npm", "start"]

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -127,6 +127,31 @@ export default ({ config, db }) => {
       .catch(next);
   });
 
+  api.post('/citeMultiple', (req, res, next) => {
+    let style = req.body.style;
+    if (!style) {
+      res.status(400).send({
+        message: 'No style provided. You must provide a CSL style path (e.g. apa.csl).'
+      });
+    }
+
+    let format = req.body.format;
+    if (!format) {
+      format = 'html';
+    }
+
+    let bibs = [];   
+
+    var actions = req.body.items.map(function(x) { 
+      return makebib.makeBib(style, format, x)
+          .then(x => bibs.push(x)); 
+      });
+
+    Promise.all(actions).then(() => {
+      console.log(bibs); res.json(bibs);
+    });    
+  });  
+
   api.get('/books', (req, res, next) => {
     /* Return a list of query results for a Book:
      * {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -99,7 +99,7 @@ export default ({ config, db }) => {
 
     let format = req.query.format;
     if (!format) {
-      format = 'rtf';
+      format = 'html';
     }
 
     console.log(style, format, req.query);
@@ -118,7 +118,7 @@ export default ({ config, db }) => {
 
     let format = req.body.format;
     if (!format) {
-      format = 'rtf';
+      format = 'html';
     }
 
     console.log(style, format, req.body);

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -99,9 +99,7 @@ export default ({ config, db }) => {
 
     let format = req.query.format;
     if (!format) {
-      res.status(400).send({
-        message: 'No format provided. You must provide a format style (e.g. rtf, html, text, asciidoc, fo)'
-      });
+      format = 'rtf';
     }
 
     console.log(style, format, req.query);
@@ -120,9 +118,7 @@ export default ({ config, db }) => {
 
     let format = req.body.format;
     if (!format) {
-      res.status(400).send({
-        message: 'No format provided. You must provide a format style (e.g. rtf, html, text, asciidoc, fo)'
-      });
+      format = 'rtf';
     }
 
     console.log(style, format, req.body);

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -97,8 +97,15 @@ export default ({ config, db }) => {
       });
     }
 
-    console.log(style, req.query);
-    makebib.makeBib(style, req.query)
+    let format = req.query.format;
+    if (!format) {
+      res.status(400).send({
+        message: 'No format provided. You must provide a format style (e.g. rtf, html, text, asciidoc, fo)'
+      });
+    }
+
+    console.log(style, format, req.query);
+    makebib.makeBib(style, format, req.query)
       .then(bib => res.json(bib))
       .catch(next);
   });
@@ -111,8 +118,15 @@ export default ({ config, db }) => {
       });
     }
 
-    console.log(style, req.body);
-    makebib.makeBib(style, req.body)
+    let format = req.body.format;
+    if (!format) {
+      res.status(400).send({
+        message: 'No format provided. You must provide a format style (e.g. rtf, html, text, asciidoc, fo)'
+      });
+    }
+
+    console.log(style, format, req.body);
+    makebib.makeBib(style, format, req.body)
       .then(bib => res.json(bib))
       .catch(next);
   });

--- a/src/api/makebib.js
+++ b/src/api/makebib.js
@@ -17,7 +17,7 @@ function loadLocales(sys, localeDir) {
   }
 }
 
-function makeBib(style, item) {
+function makeBib(style, format, item) {
   /* Generate a bibliography.
    * @param style: CSL citation style file.
    * @param item: an item in CSL-JSON format
@@ -27,7 +27,7 @@ function makeBib(style, item) {
     loadStyle("./csl", style)
       .then(styleString => {
         let engine = sys.newEngine(styleString, 'en-US', null);
-        engine.setOutputFormat("rtf"); // should be moved to a param of the request ideally
+        engine.setOutputFormat(format);
         let items = {
           "0": formatItem(item)
         };

--- a/src/api/makebib.js
+++ b/src/api/makebib.js
@@ -27,6 +27,7 @@ function makeBib(style, item) {
     loadStyle("./csl", style)
       .then(styleString => {
         let engine = sys.newEngine(styleString, 'en-US', null);
+        engine.setOutputFormat("rtf"); // should be moved to a param of the request ideally
         let items = {
           "0": formatItem(item)
         };

--- a/src/index.js
+++ b/src/index.js
@@ -20,9 +20,7 @@ app.server = http.createServer(app);
 app.use(morgan('dev'));
 
 // 3rd party middleware
-app.use(cors({
-	exposedHeaders: config.corsHeaders
-}));
+app.use(cors());
 
 app.use(bodyParser.json({
 	limit : config.bodyLimit


### PR DESCRIPTION
Updated `cite` endpoint to allow request to specify the output `format` of the citation (e.g. `html`, `rtf`, `text`).

Defaults to `html` when not specified.